### PR TITLE
Add error logging to audit_batch_status for easier replication debugging

### DIFF
--- a/.github/workflows/docker-ora2pg.yaml
+++ b/.github/workflows/docker-ora2pg.yaml
@@ -2,7 +2,7 @@ name: Push to GHCR
 
 on:
   push:
-    branches: ["BCTS-ORA2PG-LOG-ERROR-IN-AUDIT-BATCH-STATUS-TABLE"]
+    branches: ["main"]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-ora2pg.yaml
+++ b/.github/workflows/docker-ora2pg.yaml
@@ -2,7 +2,7 @@ name: Push to GHCR
 
 on:
   push:
-    branches: ["main"]
+    branches: ["BCTS-ORA2PG-LOG-ERROR-IN-AUDIT-BATCH-STATUS-TABLE"]
 
 env:
   REGISTRY: ghcr.io

--- a/shared/audit_batch_status.sql
+++ b/shared/audit_batch_status.sql
@@ -19,3 +19,7 @@ COMMENT ON COLUMN ods_data_management.audit_batch_status.application_name IS 'Na
 COMMENT ON COLUMN ods_data_management.audit_batch_status.etl_layer IS 'Layer of the ELT process (e.g., replication, transformation).';
 COMMENT ON COLUMN ods_data_management.audit_batch_status.object_execution_status IS 'Status of the ELT execution (e.g., success, failure).';
 COMMENT ON COLUMN ods_data_management.audit_batch_status.batch_run_date IS 'Most recent date that the batch ELT process took place.';
+
+-- Update 2025-03-25 Added a new column to log the errors
+ALTER TABLE ods_data_management.audit_batch_status
+ADD COLUMN error_message text NULL;

--- a/shared/audit_batch_status.sql
+++ b/shared/audit_batch_status.sql
@@ -23,3 +23,5 @@ COMMENT ON COLUMN ods_data_management.audit_batch_status.batch_run_date IS 'Most
 -- Update 2025-03-25 Added a new column to log the errors
 ALTER TABLE ods_data_management.audit_batch_status
 ADD COLUMN error_message text NULL;
+COMMENT ON COLUMN ods_data_management.audit_batch_status.error_message IS 'Error message if the replication task is failed.';
+

--- a/shared/ora2pg/data_replication_ora2pg.py
+++ b/shared/ora2pg/data_replication_ora2pg.py
@@ -78,11 +78,11 @@ def del_audit_entries_rerun(current_date):
 # Function to insert the audit batch status entry
 
 
-def audit_batch_status_insert(table_name, status):
+def audit_batch_status_insert(table_name, status, error_message=None):
     postgres_connection = PgresPool.getconn()
     postgres_cursor = postgres_connection.cursor()
     try:
-        audit_batch_status_query = f"""INSERT INTO {mstr_schema}.{audit_table} VALUES ('{table_name}','{app_name}','replication','{status}',current_date)"""
+        audit_batch_status_query = f"""INSERT INTO {mstr_schema}.{audit_table} VALUES ('{table_name}','{app_name}','replication','{status}',current_date, {error_message})"""
         print(audit_batch_status_query)
         postgres_cursor.execute(audit_batch_status_query)
         postgres_connection.commit()
@@ -143,7 +143,7 @@ def extract_from_oracle(table_name, source_schema, customsql_ind, customsql_quer
             return rows
 
     except Exception as e:
-        audit_batch_status_insert(table_name, 'failed')
+        audit_batch_status_insert(table_name, 'failed', str(e))
         print(f"Error extracting data from Oracle: {str(e)}")
         # OrcPool.release(oracle_connection)  #Temporary change
         return []
@@ -174,7 +174,7 @@ def load_into_postgres(table_name, data, target_schema):
 
     except Exception as e:
         print(f"Error loading data into PostgreSQL: {str(e)}")
-        audit_batch_status_insert(table_name, 'failed')
+        audit_batch_status_insert(table_name, 'failed', str(e))
     finally:
         # Return the connection to the pool
         if postgres_connection:
@@ -232,7 +232,7 @@ if __name__ == '__main__':
             except Exception as e:
                 # Handle exceptions that occurred during the task
                 print(f"Error replicating {table_name}: {e}")
-                audit_batch_status_insert(table_name[0], 'failed')
+                audit_batch_status_insert(table_name[0], 'failed', str(e))
 
     # record end time
     end = time.time()

--- a/shared/ora2pg/data_replication_ora2pg.py
+++ b/shared/ora2pg/data_replication_ora2pg.py
@@ -78,11 +78,11 @@ def del_audit_entries_rerun(current_date):
 # Function to insert the audit batch status entry
 
 
-def audit_batch_status_insert(table_name, status, error_message=None):
+def audit_batch_status_insert(table_name, status, error_message='None'):
     postgres_connection = PgresPool.getconn()
     postgres_cursor = postgres_connection.cursor()
     try:
-        audit_batch_status_query = f"""INSERT INTO {mstr_schema}.{audit_table} VALUES ('{table_name}','{app_name}','replication','{status}',current_date, {error_message})"""
+        audit_batch_status_query = f"""INSERT INTO {mstr_schema}.{audit_table} VALUES ('{table_name}','{app_name}','replication','{status}',current_date, '{error_message}')"""
         print(audit_batch_status_query)
         postgres_cursor.execute(audit_batch_status_query)
         postgres_connection.commit()

--- a/shared/ora2pg/data_replication_ora2pg.py
+++ b/shared/ora2pg/data_replication_ora2pg.py
@@ -82,9 +82,10 @@ def audit_batch_status_insert(table_name, status, error_message='None'):
     postgres_connection = PgresPool.getconn()
     postgres_cursor = postgres_connection.cursor()
     try:
-        audit_batch_status_query = f"""INSERT INTO {mstr_schema}.{audit_table} VALUES ('{table_name}','{app_name}','replication','{status}',current_date, '{error_message}')"""
-        print(audit_batch_status_query)
-        postgres_cursor.execute(audit_batch_status_query)
+        audit_batch_status_query = f"""INSERT INTO {mstr_schema}.{audit_table} (object_name, application_name, etl_layer, object_execution_status, batch_run_date, error_message) VALUES (%s, %s, %s, %s, current_date, %s)"""
+        values = (table_name, app_name, 'replication', status, error_message)
+        print(audit_batch_status_query, values)
+        postgres_cursor.execute(audit_batch_status_query, values)
         postgres_connection.commit()
         print("Record inserted into audit batch status table")
         return None


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Currently, the audit_batch_status table captures only the replication status, without providing details about any errors. As a result, it’s difficult to diagnose replication failures, especially since logs are not available in Airflow.

To address this, a new column error_message has been added to the audit_batch_status table, and the ora2pg script has been updated to log error messages, making it easier to debug replication issues.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
