### PR TITLE
Added TRUCNCATE privillage to bcts_etl_user on BCTS schemas

### DIFF
--- a/bcts/access_management/ddl/bcts_roles.sql
+++ b/bcts/access_management/ddl/bcts_roles.sql
@@ -20,9 +20,9 @@ GRANT USAGE ON SCHEMA bcts_staging TO bcts_etl_user WITH GRANT OPTION;
 GRANT USAGE ON SCHEMA bcts_reporting TO bcts_etl_user WITH GRANT OPTION;
 
 -- 3. Grant read and write access to existing tables in schemas lrm_replication, bcts_staging, and bcts_reporting
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA lrm_replication TO bcts_etl_user WITH GRANT OPTION;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA bcts_staging TO bcts_etl_user WITH GRANT OPTION;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA bcts_reporting TO bcts_etl_user WITH GRANT OPTION;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA lrm_replication TO bcts_etl_user WITH GRANT OPTION;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA bcts_staging TO bcts_etl_user WITH GRANT OPTION;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA bcts_reporting TO bcts_etl_user WITH GRANT OPTION;
 
 GRANT USAGE ON SCHEMA ods_data_management TO bcts_etl_user;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ods_data_management.cdc_master_table_list TO bcts_etl_user;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Added TRUNCATE permission to bcts_etl_user which is needed to run ora2pg script. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
